### PR TITLE
Add `Phone` model

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -11,7 +11,7 @@
         "dotenv": "^16.0.1",
         "fast-xml-parser": "^4.0.9",
         "firebase-admin": "^10.0.2",
-        "firebase-functions": "^3.22.0",
+        "firebase-functions": "^3.23.0",
         "lodash": "^4.17.21",
         "luxon": "^3.0.3",
         "tslib": "^2.4.0",
@@ -6796,9 +6796,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.22.0.tgz",
-      "integrity": "sha512-d1BxBpT95MhvVqXkpLWDvWbyuX7e2l69cFAiqG3U1XQDaMV88bM9S+Zg7H8i9pitEGFr+76ErjKgrY0n+g3ZDA==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.23.0.tgz",
+      "integrity": "sha512-/jujnNChTWIuoXK3IPNGYu1zjXF1fYRy88uYbkrJhs3dhK6EdXZi0rX6JUEOCB7h6IkRQvbio+bvtaoI7h+4Lg==",
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
@@ -20323,9 +20323,9 @@
       }
     },
     "firebase-functions": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.22.0.tgz",
-      "integrity": "sha512-d1BxBpT95MhvVqXkpLWDvWbyuX7e2l69cFAiqG3U1XQDaMV88bM9S+Zg7H8i9pitEGFr+76ErjKgrY0n+g3ZDA==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.23.0.tgz",
+      "integrity": "sha512-/jujnNChTWIuoXK3IPNGYu1zjXF1fYRy88uYbkrJhs3dhK6EdXZi0rX6JUEOCB7h6IkRQvbio+bvtaoI7h+4Lg==",
       "requires": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",

--- a/functions/package.json
+++ b/functions/package.json
@@ -25,7 +25,7 @@
     "dotenv": "^16.0.1",
     "fast-xml-parser": "^4.0.9",
     "firebase-admin": "^10.0.2",
-    "firebase-functions": "^3.22.0",
+    "firebase-functions": "^3.23.0",
     "lodash": "^4.17.21",
     "luxon": "^3.0.3",
     "tslib": "^2.4.0",

--- a/functions/src/Twilio.ts
+++ b/functions/src/Twilio.ts
@@ -1,14 +1,22 @@
+import * as _ from 'lodash';
 import * as functions from 'firebase-functions';
 import * as twilio from 'twilio';
 import { retryOperation } from './utils';
 import type { Twilio } from 'twilio';
 import type { MessageInstance, MessageListInstanceCreateOptions } from 'twilio/lib/rest/api/v2010/account/message';
-import type { Participant } from './models';
+import type { Participant, Phone, VerificationStatus } from './models';
 
 const TWILIO_LOG_LEVEL = process.env.TWILIO_LOG_LEVEL;
 const TWILIO_AUTH_TOKEN = process.env.TWILIO_AUTH_TOKEN;
+const TWILIO_SERVICE_SID = process.env.TWILIO_SERVICE_SID;
 const TWILIO_SID = process.env.TWILIO_SID;
 const TWILIO_PHONE_NUMBER = process.env.TWILIO_PHONE_NUMBER;
+
+type SendCodeAttempt = {
+  time: string;
+  channel: string;
+  attempt_sid: string;
+};
 
 /**
  * `TwilioClient` abstracts away actions such as sending an SMS to a Participant.
@@ -21,12 +29,45 @@ export class TwilioClient {
     this.client = twilio(TWILIO_SID, TWILIO_AUTH_TOKEN, options);
   }
 
+  /** `sendVerificationCode` sends an SMS with a verification code  */
+  sendVerificationCode = async (phone: Phone) => {
+    if (!phone) return Promise.reject(new Error('unable to verify phone number: Participant has no phone number.'));
+    return this.client.verify.v2
+      .services(TWILIO_SERVICE_SID ?? '')
+      .verifications.create({ to: phone.number, channel: 'sms' })
+      .then((verification) => {
+        const lastVerificationAttemptTime = _.last<SendCodeAttempt>(
+          verification.sendCodeAttempts as SendCodeAttempt[]
+        )?.time;
+        if (phone && lastVerificationAttemptTime) {
+          phone.lastVerificationAttemptTime = new Date(lastVerificationAttemptTime);
+          phone.verificationStatus = verification.status as VerificationStatus;
+        }
+      });
+  };
+
+  /**
+   * `verifyPhone` checks with Twilio on the verification of a phone number,
+   * given a code generated from above `sendVerificationCode`
+   */
+  verifyPhone = async (phone: Phone, code: string) =>
+    this.client.verify.v2
+      .services(TWILIO_SERVICE_SID ?? '')
+      .verificationChecks.create({ to: phone.number, code })
+      .then((verification_check) => {
+        if (verification_check.status === 'approved') {
+          phone.verificationStatus = 'approved';
+          phone.lastVerificationAttemptTime = verification_check.dateUpdated;
+        }
+        return Promise.resolve(verification_check);
+      });
+
   /** `smsParticipant` attempts to send an SMS message to a given Participant */
   smsParticipant = async (participant: Participant, message: string) => {
     if (!participant.active) return Promise.resolve();
     const msgOptions: MessageListInstanceCreateOptions = {
       from: TWILIO_PHONE_NUMBER,
-      to: participant.phone,
+      to: participant.phone?.number ?? '',
       body: message,
     };
     const makeMsgPromise = () => this.client.messages.create(msgOptions);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,11 +1,14 @@
+import * as _ from 'lodash';
 import * as functions from 'firebase-functions';
 import './firebase'; // Keep near top, initializes Firebase app
 import { CRON_FREQUENCY, NTWC_TSUNAMI_FEED_URL } from './constants';
 import * as AtomFeed from './AtomFeed';
 import { Alert, Participant, Phone } from './models';
-import { fetchXMLDocument } from './utils';
-import type { ParticipantArgs } from './models';
 import Twilio from './Twilio';
+import { fetchXMLDocument } from './utils';
+import type { ParticipantArgs, VerificationStatus } from './models';
+import type { SendCodeAttempt, VerificationInstance, VerificationCheckInstance } from './Twilio';
+import { DBPhone, getVerificationStatus } from './models/Phone';
 
 export const scheduledFetchAndParseLatestEvents = functions.pubsub.schedule(CRON_FREQUENCY).onRun((context) => {
   functions.logger.log(`scheduledFetchAndParseLatestEvents runs ${CRON_FREQUENCY}`, context);
@@ -107,41 +110,55 @@ export const manuallyAddAlert = functions.https.onRequest(async (req, res) => {
 
 export const sendVerificationCodeOnPhoneCreate = functions.database
   .ref('/participants/{id}/phone')
-  .onCreate(async (snapshot, context) => {
+  .onCreate(async (snapshot, context): Promise<DBPhone> => {
     const phone = Phone.fromDB(snapshot.val(), context.params.id);
-    await Twilio.sendVerificationCode(phone)
-      .then(() => phone.update())
-      .then(() => {
-        functions.logger.log(`Successfully sent verification code to phone`, phone.toDB());
-      })
+    let verification: VerificationInstance;
+    try {
+      verification = await Twilio.sendVerificationCode(phone.number);
+    } catch (err: any) {
+      const errMsg = `Unable to send verification code to phone '${phone.number}': ${err}`;
+      functions.logger.log(errMsg);
+      return Promise.reject(errMsg);
+    }
+
+    const lastVerificationAttempt = _.last<SendCodeAttempt>(verification.sendCodeAttempts as SendCodeAttempt[]);
+    if (lastVerificationAttempt?.time) phone.lastVerificationAttemptTime = new Date(lastVerificationAttempt.time);
+
+    phone.verificationStatus = getVerificationStatus(verification.status as VerificationStatus);
+    return phone
+      .update()
+      .then((updatedPhone) => updatedPhone.toDB())
       .catch((err) => {
-        functions.logger.log(`Unable to send verification code to phone '${phone.number}': ${err}`);
+        const errMsg = `Unable to send verification code to phone '${phone.number}': ${err}`;
+        functions.logger.log(errMsg, phone.toDB());
+        return Promise.reject(errMsg);
       });
   });
 
-export const attemptVerifyPhone = functions.https.onCall(async (data: { code: string }, context) => {
-  if (!context.auth?.uid) return Promise.reject('Must be signed in to do that.');
-  if (!data.code) return Promise.reject("Must include a 'code' argument in the body");
+export const attemptVerifyPhone = functions.https.onCall(async (data: { code: string }, context): Promise<DBPhone> => {
+  if (!context.auth?.uid) return Promise.reject('Unable to verify phone: must be signed in');
+  if (!data.code) return Promise.reject("Unable to verify phone: must include a 'code' argument in the body");
   if (!Number.parseInt(data.code, 10)) return Promise.reject("'code' argument must be a valid number");
 
   const participant = await Participant.find(context.auth.uid);
-  if (!participant.phone) return Promise.reject('Must have a phone on record to verify it');
+  if (!participant.phone) return Promise.reject('Unable to verify phone: must have a phone on record to verify it');
   const phone = participant.phone;
 
-  return Twilio.verifyPhone(phone, data.code)
-    .then(() =>
-      phone
-        .update()
-        .then(() => {
-          functions.logger.log(`Successfully verified phone`, phone.toDB());
-          return Promise.resolve('Successfully verified phone!');
-        })
-        .catch((err) => {
-          const errMsg = `Unable to verify phone: ${err}`;
-          functions.logger.log(errMsg, phone.toDB());
-          return Promise.reject(errMsg);
-        })
-    )
+  let verificationCheck: VerificationCheckInstance;
+  try {
+    verificationCheck = await Twilio.verifyPhone(phone.number, data.code);
+  } catch (err: any) {
+    const errMsg = `Unable to verify phone: ${err}`;
+    functions.logger.log(errMsg, phone.toDB());
+    return Promise.reject(errMsg);
+  }
+
+  phone.verificationStatus = getVerificationStatus(verificationCheck.status as VerificationStatus);
+  phone.lastVerificationAttemptTime = verificationCheck.dateUpdated;
+
+  return phone
+    .update()
+    .then((updatedPhone) => updatedPhone.toDB())
     .catch((err) => {
       const errMsg = `Unable to verify phone: ${err}`;
       functions.logger.log(errMsg, phone.toDB());

--- a/functions/src/models/Participant.ts
+++ b/functions/src/models/Participant.ts
@@ -4,6 +4,8 @@ import { v4 as uuidv4 } from 'uuid';
 import Phone from './Phone';
 import type { DBPhone } from './Phone';
 
+const DB_PATH = 'participants';
+
 type DBParticipant = {
   id: string;
   active: boolean;
@@ -39,7 +41,10 @@ export default class Participant {
   static fromDB = (dbParticipant: DBParticipant) =>
     new Participant({
       ...dbParticipant,
-      phone: dbParticipant?.phone ? Phone.fromDB(dbParticipant.phone) : undefined,
+      phone:
+        Object.values(dbParticipant?.phone ?? {})?.length > 0
+          ? Phone.fromDB(dbParticipant.phone as DBPhone, dbParticipant.id)
+          : undefined,
       email: dbParticipant?.email ?? '',
       displayName: dbParticipant?.displayName ?? '',
     });
@@ -51,7 +56,7 @@ export default class Participant {
     admin
       .database()
       .ref()
-      .child(`participants/${this.id}`)
+      .child(getParticipantRef(this.id))
       .set(this.toDB(), (err) => {
         if (err) {
           const errMsg = `Unable to add new Participant with ID '${this.id}': ${err}`;
@@ -67,12 +72,31 @@ export default class Participant {
       .catch((err) => Promise.reject(err));
 
   /**
+   * `find` attempts to find an existing Participant.
+   */
+  static find = async (id: string): Promise<Participant> => {
+    const ref = getParticipantRef(id ?? '');
+    functions.logger.log(`Attempting to find Participant with ID '${ref}'`);
+    return admin
+      .database()
+      .ref(ref)
+      .once('value')
+      .then((snapshot) => {
+        if (snapshot.exists()) return Participant.fromDB({ ...snapshot.val(), id });
+        return Promise.reject(new Error('Participant does not exist'));
+      })
+      .catch((err) => {
+        return Promise.reject(new Error(`Unable to find Participant: ${err}`));
+      });
+  };
+
+  /**
    * `findOrCreate` returns an existing Participant or creates it.
    */
-  static findOrCreate = async (args: ParticipantArgs): Promise<Participant> =>
-    admin
+  static findOrCreate = async (args: ParticipantArgs): Promise<Participant> => {
+    return admin
       .database()
-      .ref(`participants/${args.id}`)
+      .ref(getParticipantRef(args.id ?? ''))
       .once('value')
       .then((snapshot) => {
         if (!snapshot.exists()) return new Participant(args).create();
@@ -81,12 +105,13 @@ export default class Participant {
         return Participant.fromDB(existingParticipant);
       })
       .catch((err) => Promise.reject(new Error(`unable to find Participant '${args.id}': ${err}`)));
+  };
 
   static getAllActive = async () => {
     const activeParticipants: Participant[] = [];
     await admin
       .database()
-      .ref('participants')
+      .ref(DB_PATH)
       .orderByChild('active')
       .once('value')
       .then((snapshot) => {
@@ -107,3 +132,5 @@ export default class Participant {
     return dbParticipant;
   };
 }
+
+export const getParticipantRef = (id: string) => `${DB_PATH}/${id}`;

--- a/functions/src/models/Participant.ts
+++ b/functions/src/models/Participant.ts
@@ -1,18 +1,20 @@
 import * as admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
 import { v4 as uuidv4 } from 'uuid';
+import Phone from './Phone';
+import type { DBPhone } from './Phone';
 
 type DBParticipant = {
   id: string;
   active: boolean;
-  phone?: string;
+  phone?: DBPhone;
   email?: string;
   displayName?: string;
 };
 
 export type ParticipantArgs = {
-  phone?: string;
   id?: string;
+  phone?: Phone;
   active?: boolean;
   email?: string;
   displayName?: string;
@@ -20,14 +22,14 @@ export type ParticipantArgs = {
 
 export default class Participant {
   id: string;
-  phone: string;
   active: boolean;
   email: string;
   displayName: string;
+  phone: Phone | undefined;
 
   constructor(args: ParticipantArgs) {
     this.id = args.id ?? uuidv4();
-    this.phone = args.phone ?? '';
+    this.phone = args.phone;
     this.email = args.email ?? '';
     this.displayName = args.displayName ?? '';
     this.active = args.active ?? false;
@@ -37,7 +39,7 @@ export default class Participant {
   static fromDB = (dbParticipant: DBParticipant) =>
     new Participant({
       ...dbParticipant,
-      phone: dbParticipant?.phone ?? '',
+      phone: dbParticipant?.phone ? Phone.fromDB(dbParticipant.phone) : undefined,
       email: dbParticipant?.email ?? '',
       displayName: dbParticipant?.displayName ?? '',
     });
@@ -99,7 +101,7 @@ export default class Participant {
       id: this.id,
       active: this.active,
     };
-    if (this.phone) dbParticipant.phone = this.phone;
+    if (this.phone) dbParticipant.phone = this.phone.toDB();
     if (this.email) dbParticipant.email = this.email;
     if (this.displayName) dbParticipant.displayName = this.displayName;
     return dbParticipant;

--- a/functions/src/models/Phone.ts
+++ b/functions/src/models/Phone.ts
@@ -3,6 +3,13 @@ import * as functions from 'firebase-functions';
 import { getParticipantRef } from './Participant';
 
 export type VerificationStatus = 'pending' | 'approved' | 'canceled';
+export const getVerificationStatus = (statusStr: VerificationStatus | undefined): VerificationStatus | undefined => {
+  if (!statusStr) return undefined;
+  if (new Set<VerificationStatus>(['pending', 'approved', 'canceled']).has(statusStr)) return statusStr;
+
+  return undefined;
+};
+
 export type DBPhone = {
   number: string;
   verificationStatus?: VerificationStatus;
@@ -11,7 +18,7 @@ export type DBPhone = {
 
 type PhoneArgs = DBPhone & {
   participantID: string;
-  verificationStatus: VerificationStatus | undefined;
+  verificationStatus?: VerificationStatus;
 };
 
 class Phone {
@@ -23,7 +30,7 @@ class Phone {
   constructor(args: PhoneArgs) {
     this.participantID = args.participantID;
     this.number = args.number;
-    this.verificationStatus = args.verificationStatus;
+    this.verificationStatus = getVerificationStatus(args.verificationStatus);
     this.lastVerificationAttemptTime = args.lastVerificationAttemptTime
       ? new Date(args.lastVerificationAttemptTime)
       : undefined;
@@ -64,7 +71,7 @@ class Phone {
     const dbPhone: DBPhone = {
       number: this.number,
     };
-    if (this.verificationStatus) dbPhone.verificationStatus = this.verificationStatus;
+    if (getVerificationStatus(this.verificationStatus)) dbPhone.verificationStatus = this.verificationStatus;
     if (this.lastVerificationAttemptTime)
       dbPhone.lastVerificationAttemptTime = this.lastVerificationAttemptTime.toISOString();
 

--- a/functions/src/models/Phone.ts
+++ b/functions/src/models/Phone.ts
@@ -1,0 +1,46 @@
+type VerificationStatus = 'pending' | 'approved' | 'canceled';
+export type DBPhone = {
+  number: string;
+  verificationStatus?: VerificationStatus;
+  lastVerificationAttemptTime?: string;
+};
+
+type PhoneArgs = DBPhone & {
+  verificationStatus: VerificationStatus | undefined;
+};
+
+class Phone {
+  readonly number: string;
+  verificationStatus: VerificationStatus | undefined;
+  lastVerificationAttemptTime: Date | undefined;
+
+  constructor(args: PhoneArgs) {
+    this.number = args.number;
+    this.verificationStatus = args.verificationStatus;
+    this.lastVerificationAttemptTime = args.lastVerificationAttemptTime
+      ? new Date(args.lastVerificationAttemptTime)
+      : undefined;
+  }
+
+  /** `fromDB` converts a DBPhone to an Phone instance */
+  static fromDB = (dbPhone: DBPhone) =>
+    new Phone({
+      number: dbPhone.number,
+      verificationStatus: dbPhone?.verificationStatus,
+      lastVerificationAttemptTime: dbPhone?.lastVerificationAttemptTime,
+    });
+
+  /** `toDB` converts an Phone to a DBPhone POJO. */
+  toDB = (): DBPhone => {
+    const dbPhone: DBPhone = {
+      number: this.number,
+    };
+    if (this.verificationStatus) dbPhone.verificationStatus = this.verificationStatus;
+    if (this.lastVerificationAttemptTime)
+      dbPhone.lastVerificationAttemptTime = this.lastVerificationAttemptTime.toUTCString();
+
+    return dbPhone;
+  };
+}
+
+export default Phone;

--- a/functions/src/models/Phone.ts
+++ b/functions/src/models/Phone.ts
@@ -1,4 +1,8 @@
-type VerificationStatus = 'pending' | 'approved' | 'canceled';
+import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+import { getParticipantRef } from './Participant';
+
+export type VerificationStatus = 'pending' | 'approved' | 'canceled';
 export type DBPhone = {
   number: string;
   verificationStatus?: VerificationStatus;
@@ -6,15 +10,18 @@ export type DBPhone = {
 };
 
 type PhoneArgs = DBPhone & {
+  participantID: string;
   verificationStatus: VerificationStatus | undefined;
 };
 
 class Phone {
+  readonly participantID: string;
   readonly number: string;
   verificationStatus: VerificationStatus | undefined;
   lastVerificationAttemptTime: Date | undefined;
 
   constructor(args: PhoneArgs) {
+    this.participantID = args.participantID;
     this.number = args.number;
     this.verificationStatus = args.verificationStatus;
     this.lastVerificationAttemptTime = args.lastVerificationAttemptTime
@@ -23,12 +30,34 @@ class Phone {
   }
 
   /** `fromDB` converts a DBPhone to an Phone instance */
-  static fromDB = (dbPhone: DBPhone) =>
+  static fromDB = (dbPhone: DBPhone, participantID: string) =>
     new Phone({
+      participantID,
       number: dbPhone.number,
       verificationStatus: dbPhone?.verificationStatus,
       lastVerificationAttemptTime: dbPhone?.lastVerificationAttemptTime,
     });
+
+  /** `update` updates only the Phone child of a Participant */
+  update = async (): Promise<Phone> => {
+    if (!this.participantID) return Promise.reject(new Error('No ParticipantID set on Phone'));
+    return admin
+      .database()
+      .ref(getPhoneRef(this.participantID))
+      .set(this.toDB(), (err) => {
+        if (err) {
+          const errMsg = `Unable to update Phone with Participant ID '${this.participantID}': ${err}`;
+          functions.logger.error(errMsg, err);
+          return Promise.reject(errMsg);
+        }
+        return Promise.resolve(this);
+      })
+      .then(() => {
+        functions.logger.log(`Successfully updated Phone with Participant ID '${this.participantID}'`, this.toDB());
+        return Promise.resolve(this);
+      })
+      .catch((err) => Promise.reject(err));
+  };
 
   /** `toDB` converts an Phone to a DBPhone POJO. */
   toDB = (): DBPhone => {
@@ -37,10 +66,12 @@ class Phone {
     };
     if (this.verificationStatus) dbPhone.verificationStatus = this.verificationStatus;
     if (this.lastVerificationAttemptTime)
-      dbPhone.lastVerificationAttemptTime = this.lastVerificationAttemptTime.toUTCString();
+      dbPhone.lastVerificationAttemptTime = this.lastVerificationAttemptTime.toISOString();
 
     return dbPhone;
   };
 }
+
+const getPhoneRef = (participantID: string) => `${getParticipantRef(participantID)}/phone`;
 
 export default Phone;

--- a/functions/src/models/index.ts
+++ b/functions/src/models/index.ts
@@ -1,10 +1,11 @@
 import Alert from './Alert';
 import Event from './Event';
 import Participant from './Participant';
+import Phone from './Phone';
 import Geo from './Geo';
-import type { DBAlert } from './Alert';
-import type { DBEvent } from './Event';
-import type { ParticipantArgs } from './Participant';
+export type { DBAlert } from './Alert';
+export type { DBEvent } from './Event';
+export type { ParticipantArgs } from './Participant';
+export type { VerificationStatus } from './Phone';
 
-export { Alert, Event, Participant, Geo };
-export type { DBAlert, DBEvent, ParticipantArgs };
+export { Alert, Event, Geo, Participant, Phone };

--- a/functions/src/test/Participant.test.ts
+++ b/functions/src/test/Participant.test.ts
@@ -1,5 +1,5 @@
 import { validate } from 'uuid';
-import { Participant } from '../models';
+import { Participant, Phone } from '../models';
 import type { ParticipantArgs } from '../models';
 
 describe('Participant', () => {
@@ -7,7 +7,7 @@ describe('Participant', () => {
   const defaultParticipant = new Participant(defaultArgs);
   const fullArgs: ParticipantArgs = {
     id: 'abcd-1234',
-    phone: '415-867-5309',
+    phone: new Phone({ number: '415-867-5309', participantID: 'abcd-1234' }),
     email: 'phil@gresham.dev',
     displayName: 'Phil',
     active: true,
@@ -34,15 +34,15 @@ describe('Participant', () => {
     it('sets all fields from DBParticipant args', () => {
       const fromDB = Participant.fromDB({
         id: 'abcd-1234',
-        phone: '415-867-5309',
+        phone: { number: '415-867-5309' },
         email: 'phil@gresham.dev',
         displayName: 'Phil',
         active: true,
       });
       expect(fromDB.id).toBe(fullParticipant.id);
-      expect(fromDB.phone).toBe(fullParticipant.phone);
       expect(fromDB.email).toBe(fullParticipant.email);
       expect(fromDB.active).toBe(fullParticipant.active);
+      expect(fromDB.phone).toMatchObject(fullParticipant.phone?.toDB() ?? {});
     });
   });
 
@@ -50,9 +50,9 @@ describe('Participant', () => {
     it('sets all fields from DBParticipant args', () => {
       const toDB = fullParticipant.toDB();
       expect(toDB.id).toBe(fullParticipant.id);
-      expect(toDB.phone).toBe(fullParticipant.phone);
       expect(toDB.email).toBe(fullParticipant.email);
       expect(toDB.active).toBe(fullParticipant.active);
+      expect(toDB.phone).toMatchObject(fullParticipant.phone?.toDB() ?? {});
     });
   });
 });

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -8,7 +8,8 @@
     "sourceMap": true,
     "strict": true,
     "target": "es2021",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "skipLibCheck": true
   },
   "compileOnSave": true,
   "include": ["src/**/*.ts", "../src/models/Event.ts"],


### PR DESCRIPTION
This PR adds the `Phone` model, adds a DB-triggered `sendVerificationCodeOnPhoneCreate` function, and adds an `onCall` `attemptVerifyPhone` function. We want to use the `approved` verification status to only send SMS messages to verified phone numbers. The happy path is:
- User adds a phone number via the frontend (see https://github.com/philgresh/tsunami-alert-gcp/tree/f/pg/add-phone for that work)
- `sendVerificationCodeOnPhoneCreate` is triggered and sends a request to Twilio to send a verification SMS to the phone number provided. We add the current `pending` status and update time to the `Phone` entry in the DB
  - Note: We do not currently implement validation of the given phone number on the backend but will use the built-in validation on the frontend `mui-tel-input` library
- The user receives the verification code on their phone
- The user inputs the verification code into the frontend interface (forthcoming) and sends a request to `attemptVerifyPhone`
- We check the code with Twilio and update the `Phone` entry in the DB, and respond appropriately

