### PR TITLE
Config ESLint `import/order` (frontend)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "babel-plugin-import": "^1.13.5",
         "babel-plugin-named-exports-order": "^0.0.2",
         "customize-cra": "^1.0.0",
+        "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jsx-a11y": "^6.6.1",
         "eslint-plugin-testing-library": "^5.6.2",
         "firebase-functions-test": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "test": "react-app-rewired test",
     "test:coverage": "npm test -- --coverage --changedSince=main --collectCoverageFrom=src/**/* --collectCoverageFrom=!src/**/*.stories.*",
     "eject": "react-scripts eject",
-    "lint": "eslint --ext .js,.ts,.tsx ./src",
+    "lint": "eslint --ext .js,.ts,.tsx ./src --max-warnings 100",
+    "lint:fix": "eslint --ext .js,.ts,.tsx ./src --fix",
     "emulators:start": "export env='LOCAL' && firebase emulators:start --import=\"./local_data\"",
     "emulators:start:export": "export env='LOCAL' && firebase emulators:start --import=\"./local_data\" --export-on-exit",
     "storybook": "start-storybook -p 6006 -s public",
@@ -52,7 +53,36 @@
       "plugin:jsx-a11y/recommended"
     ],
     "rules": {
-      "jsx-a11y/no-autofocus": "off"
+      "jsx-a11y/no-autofocus": "off",
+      "import/order": [
+        "error",
+        {
+          "groups": [
+            "builtin",
+            "external",
+            "internal",
+            "parent",
+            "sibling",
+            "index",
+            "object",
+            "type"
+          ],
+          "pathGroups": [
+            {
+              "pattern": "react",
+              "group": "external",
+              "position": "before"
+            }
+          ],
+          "pathGroupsExcludedImportTypes": [
+            "react"
+          ],
+          "alphabetize": {
+            "order": "asc",
+            "caseInsensitive": true
+          }
+        }
+      ]
     },
     "overrides": [
       {
@@ -112,6 +142,7 @@
     "babel-plugin-import": "^1.13.5",
     "babel-plugin-named-exports-order": "^0.0.2",
     "customize-cra": "^1.0.0",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-testing-library": "^5.6.2",
     "firebase-functions-test": "^2.3.0",

--- a/src/Account/Phone/components/VerifyPhoneDialog.tsx
+++ b/src/Account/Phone/components/VerifyPhoneDialog.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import Button from '@mui/material/Button';
-import TextField from '@mui/material/TextField';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
+import TextField from '@mui/material/TextField';
 
 const CODE_LENGTH = 6;
 

--- a/src/Account/Phone/functions.ts
+++ b/src/Account/Phone/functions.ts
@@ -1,8 +1,8 @@
 import { set } from 'firebase/database';
 import { getFunctions, httpsCallable } from 'firebase/functions';
 import { getPhoneRef } from './utils';
-import type { HttpsCallable } from 'firebase/functions';
 import type { Phone, DBPhone } from '../../models';
+import type { HttpsCallable } from 'firebase/functions';
 
 export type AttemptVerifyPhoneType = HttpsCallable<{ code: string }, DBPhone>;
 export type SetUserPhoneType = (phone: Phone) => Promise<void>;

--- a/src/Account/Phone/index.tsx
+++ b/src/Account/Phone/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { useObjectVal } from 'react-firebase-hooks/database';
 import { CircularProgress, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
+import { useObjectVal } from 'react-firebase-hooks/database';
 import { Phone } from '../../models';
 import { AddPhone, ExistingPhone, VerifyPhoneDialog } from './components';
+import { attemptVerifyPhone, setUserPhone } from './functions';
 import { useVerifyPhone } from './hooks';
 import { getPhoneNumberDisplay, getPhoneRef } from './utils';
-import { attemptVerifyPhone, setUserPhone } from './functions';
 import type { ValOptions } from 'react-firebase-hooks/database/dist/database/helpers';
 
 export type PhoneControllerProps = {

--- a/src/Account/Phone/utils.ts
+++ b/src/Account/Phone/utils.ts
@@ -1,5 +1,5 @@
-import parsePhoneNumber from 'libphonenumber-js';
 import { ref, getDatabase } from 'firebase/database';
+import parsePhoneNumber from 'libphonenumber-js';
 import { DEFAULT_COUNTRY } from './constants';
 
 const EXPOSED_DIGITS_LENGTH = 4;

--- a/src/Nav/UserMenu.tsx
+++ b/src/Nav/UserMenu.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
+import type { MouseEvent } from 'react';
+import { Avatar, Box, IconButton, Menu, MenuItem, Tooltip, Typography } from '@mui/material';
 import { getAuth } from 'firebase/auth';
 import { Link as RouterLink } from 'react-router-dom';
-import { Avatar, Box, IconButton, Menu, MenuItem, Tooltip, Typography } from '@mui/material';
 import { NavPath } from '../constants';
 import { stringAvatar } from './utils';
-import type { MouseEvent } from 'react';
 import type { NavItem } from './types';
 
 type Props = {

--- a/src/Nav/index.tsx
+++ b/src/Nav/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
+import type { MouseEvent } from 'react';
+import { Menu as MenuIcon } from '@mui/icons-material';
 import {
   AppBar,
   Box,
@@ -14,14 +15,13 @@ import {
   Toolbar,
   Typography,
 } from '@mui/material';
-import { Menu as MenuIcon } from '@mui/icons-material';
 import { getAuth } from 'firebase/auth';
+import { Link as RouterLink } from 'react-router-dom';
 import { NavPath, NAVBAR_HEIGHT } from '../constants';
-import UserMenu from './UserMenu';
 import { DRAWER_WIDTH, NAV_ITEMS } from './constants';
-import { useRouteMatch } from './utils';
 import Loading from './Loading';
-import type { MouseEvent } from 'react';
+import UserMenu from './UserMenu';
+import { useRouteMatch } from './utils';
 
 /** `NavTabs` renders routing buttons on desktop nav bar.
  * @link https://mui.com/material-ui/guides/routing/#button

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,11 +1,11 @@
 import React, { Suspense, lazy, memo } from 'react';
-import { BrowserRouter, Navigate, Outlet, Routes, Route } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import Container from '@mui/material/Container';
 import { getAuth } from 'firebase/auth';
 import { useAuthState } from 'react-firebase-hooks/auth';
-import Container from '@mui/material/Container';
-import Navbar, { Loading } from './Nav';
+import { BrowserRouter, Navigate, Outlet, Routes, Route } from 'react-router-dom';
 import { NavPath, NAVBAR_HEIGHT } from './constants';
-import type { ReactNode } from 'react';
+import Navbar, { Loading } from './Nav';
 
 const Signin = lazy(() => import('./auth/Signin'));
 const Account = lazy(() => import('./Account'));

--- a/src/auth/Signin/index.tsx
+++ b/src/auth/Signin/index.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react';
 import { getAuth, EmailAuthProvider, GoogleAuthProvider, GithubAuthProvider } from 'firebase/auth';
-import { useNavigate } from 'react-router-dom';
 import { useAuthState } from 'react-firebase-hooks/auth';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import { NavPath } from '../../constants';
 import StyledFirebaseAuth from '../StyledFirebaseUI';
 import 'firebaseui/dist/firebaseui.css';
-import { NavPath } from '../../constants';
 import type * as firebaseui from 'firebaseui';
 
 const StyledContainer = styled.div`

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,5 +1,5 @@
-import { initializeApp } from 'firebase/app';
 import { getAnalytics } from 'firebase/analytics';
+import { initializeApp } from 'firebase/app';
 import { getPerformance } from 'firebase/performance';
 
 const firebaseConfig = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,13 +1,13 @@
 import React, { useMemo, StrictMode } from 'react';
+import CssBaseline from '@mui/material/CssBaseline';
+import { ThemeProvider } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import ReactDOM from 'react-dom/client';
 import Helmet from 'react-helmet';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { ThemeProvider } from '@mui/material/styles';
-import CssBaseline from '@mui/material/CssBaseline';
 import './firebase'; // Keep as one of the first imports since the FIrebase app is initialized here
-import Router from './Router';
-import reportWebVitals from './reportWebVitals';
 import { createTheme } from './material';
+import reportWebVitals from './reportWebVitals';
+import Router from './Router';
 
 const App = () => {
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');

--- a/src/material.tsx
+++ b/src/material.tsx
@@ -1,8 +1,8 @@
-import { createTheme as MuiCreateTheme, ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
+import React from 'react';
 import { cyan, purple } from '@mui/material/colors';
+import { createTheme as MuiCreateTheme, ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
 import { deepmerge } from '@mui/utils';
 import type { ThemeOptions } from '@mui/material/styles';
-import React from 'react';
 
 /**
  * `createTheme` creates a theme based on whether or not the user prefers dark mode.


### PR DESCRIPTION
This PR configures ESLint to ["enforce a convention in module import order"](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md) on the frontend, and applies such changes.

See https://dev.to/otamnitram/sorting-your-imports-correctly-in-react-213m for changes specific to React