### PR TITLE
Adjust `SendAlert` message

### DIFF
--- a/functions/src/models/Alert/index.ts
+++ b/functions/src/models/Alert/index.ts
@@ -10,7 +10,6 @@ import type { AlertArgs, DBAlert } from './types';
  * `Alert` is the main model for the CAP_1_2 Alert (slightly extended). `Events` may reference multiple `Alerts`.
  */
 export default class Alert {
-  /** `eventID` cross-references an Event */
   identifier: string;
   sender: string;
   sent: string;
@@ -23,6 +22,7 @@ export default class Alert {
 
   addresses?: string;
   alertLevel?: AlertLevel;
+  /** `eventID` cross-references an Event */
   eventID?: string;
   incidents?: string;
   manuallyAdded?: boolean;

--- a/functions/src/models/Alert/index.ts
+++ b/functions/src/models/Alert/index.ts
@@ -2,96 +2,15 @@ import * as admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
 import { isNil } from 'lodash';
 import { CAP_1_2 } from 'cap-ts';
-
-/**
- * `AlertLevel` represents a high-level idea of the severity/impact of a tsunami event.
- * @link https://tsunami.gov/?page=message_definitions
- * @link https://tsunami.gov/images/procChartLargePacific.gif
- */
-export enum AlertLevel {
-  DO_NOT_USE,
-  /** `Cancellation` is an information-only alert level.   */
-  Cancellation,
-
-  /** `Information` is an information-only alert level.
-   * There are no threats or this is a very distant event for which hazards have not been determined.
-   */
-  Information,
-
-  /** `Watch` is an intermediate alert level.
-   * Potential hazards are not yet known.
-   * Actions recommended include staying tuned for more info and getting prepared to act.
-   */
-  Watch,
-
-  /** `Advisory` is a moderately severe alert level.
-   * Potential hazards include strong currents and waves dangerous to those in or very near water.
-   * Actions recommended include staying out of water, away from beaches and waterways.
-   */
-  Advisory,
-
-  /** `Warning` is the most severe alert level.
-   * Potential hazards include dangerous coastal flooding and powerful currents.
-   * Actions recommended include moving to high ground or inland.
-   */
-  Warning,
-}
-/**
- * `DBAlert` represents the shape of an Alert on the database.
- * Note: Realtime Database does not allow `undefined` values so we strip those via the `toDB` method.
- */
-export type DBAlert = {
-  identifier: string;
-  sender: string;
-  sent: string;
-  status: string;
-  msgType: string;
-  scope: string;
-  code_list: string[];
-  info_list: CAP_1_2.Alert_info_list_info_toJSON_type[];
-  elem_list: string[];
-  addresses?: string;
-  alertLevel?: keyof typeof AlertLevel;
-  eventID?: string;
-  incidents?: string;
-  manuallyAdded?: boolean;
-  note?: string;
-  references?: string;
-  restriction?: string;
-  source?: string;
-  url?: string;
-};
-
-/**
- * `getAlertLevel` returns the AlertLevel enum value of an equivalent string.
- */
-const getAlertLevel = (str: string): AlertLevel => {
-  if (!str?.toLowerCase()) return AlertLevel.DO_NOT_USE;
-
-  if (str.toLowerCase().includes('warning')) return AlertLevel.Warning;
-  if (str.toLowerCase().includes('advisory')) return AlertLevel.Advisory;
-  if (str.toLowerCase().includes('watch')) return AlertLevel.Watch;
-  if (str.toLowerCase().includes('information')) return AlertLevel.Information;
-  if (str.toLowerCase().includes('cancelation')) return AlertLevel.Cancellation;
-  if (str.toLowerCase().includes('cancellation')) return AlertLevel.Cancellation;
-
-  return AlertLevel.DO_NOT_USE;
-};
-
-export type AlertArgs = {
-  alertJSON: CAP_1_2.Alert_toJSON_type;
-  alertLevel?: keyof typeof AlertLevel;
-  eventID?: string;
-  manuallyAdded?: boolean;
-  url?: string;
-};
+import { AlertLevel } from './types';
+import { getAlertLevel } from './utils';
+import type { AlertArgs, DBAlert } from './types';
 
 /**
  * `Alert` is the main model for the CAP_1_2 Alert (slightly extended). `Events` may reference multiple `Alerts`.
  */
 export default class Alert {
   /** `eventID` cross-references an Event */
-  eventID?: string;
   identifier: string;
   sender: string;
   sent: string;
@@ -101,15 +20,17 @@ export default class Alert {
   code_list: string[];
   info_list: CAP_1_2.Alert_info_list_info_toJSON_type[];
   elem_list: string[];
+
   addresses?: string;
-  references?: string;
-  source?: string;
-  incidents?: string;
-  restriction?: string;
-  note?: string;
-  url?: string;
   alertLevel?: AlertLevel;
+  eventID?: string;
+  incidents?: string;
   manuallyAdded?: boolean;
+  note?: string;
+  references?: string;
+  restriction?: string;
+  source?: string;
+  url?: string;
 
   constructor(args: AlertArgs) {
     const { alertJSON, alertLevel, eventID, manuallyAdded, url } = args;

--- a/functions/src/models/Alert/types.ts
+++ b/functions/src/models/Alert/types.ts
@@ -1,0 +1,68 @@
+import { CAP_1_2 } from 'cap-ts';
+
+/**
+ * `AlertLevel` represents a high-level idea of the severity/impact of a tsunami event.
+ * @link https://tsunami.gov/?page=message_definitions
+ * @link https://tsunami.gov/images/procChartLargePacific.gif
+ */
+export enum AlertLevel {
+  DO_NOT_USE,
+  /** `Cancellation` is an information-only alert level.   */
+  Cancellation,
+
+  /** `Information` is an information-only alert level.
+   * There are no threats or this is a very distant event for which hazards have not been determined.
+   */
+  Information,
+
+  /** `Watch` is an intermediate alert level.
+   * Potential hazards are not yet known.
+   * Actions recommended include staying tuned for more info and getting prepared to act.
+   */
+  Watch,
+
+  /** `Advisory` is a moderately severe alert level.
+   * Potential hazards include strong currents and waves dangerous to those in or very near water.
+   * Actions recommended include staying out of water, away from beaches and waterways.
+   */
+  Advisory,
+
+  /** `Warning` is the most severe alert level.
+   * Potential hazards include dangerous coastal flooding and powerful currents.
+   * Actions recommended include moving to high ground or inland.
+   */
+  Warning,
+}
+/**
+ * `DBAlert` represents the shape of an Alert on the database.
+ * Note: Realtime Database does not allow `undefined` values so we strip those via the `toDB` method.
+ */
+export type DBAlert = {
+  identifier: string;
+  sender: string;
+  sent: string;
+  status: string;
+  msgType: string;
+  scope: string;
+  code_list: string[];
+  info_list: CAP_1_2.Alert_info_list_info_toJSON_type[];
+  elem_list: string[];
+  addresses?: string;
+  alertLevel?: keyof typeof AlertLevel;
+  eventID?: string;
+  incidents?: string;
+  manuallyAdded?: boolean;
+  note?: string;
+  references?: string;
+  restriction?: string;
+  source?: string;
+  url?: string;
+};
+
+export type AlertArgs = {
+  alertJSON: CAP_1_2.Alert_toJSON_type;
+  alertLevel?: keyof typeof AlertLevel;
+  eventID?: string;
+  manuallyAdded?: boolean;
+  url?: string;
+};

--- a/functions/src/models/Alert/types.ts
+++ b/functions/src/models/Alert/types.ts
@@ -49,6 +49,7 @@ export type DBAlert = {
   elem_list: string[];
   addresses?: string;
   alertLevel?: keyof typeof AlertLevel;
+  earthquakeLocDesc?: string;
   eventID?: string;
   incidents?: string;
   manuallyAdded?: boolean;
@@ -62,6 +63,7 @@ export type DBAlert = {
 export type AlertArgs = {
   alertJSON: CAP_1_2.Alert_toJSON_type;
   alertLevel?: keyof typeof AlertLevel;
+  earthquakeLocDesc?: string;
   eventID?: string;
   manuallyAdded?: boolean;
   url?: string;

--- a/functions/src/models/Alert/utils.ts
+++ b/functions/src/models/Alert/utils.ts
@@ -1,4 +1,8 @@
+import { CAP_1_2 } from 'cap-ts';
 import { AlertLevel } from './types';
+
+const EVENT_LOC_NAME_VALUENAME = 'EventLocationName';
+const EVENT_PRELIM_MAG_VALUENAME = 'EventPreliminaryMagnitude';
 
 /**
  * `getAlertLevel` returns the AlertLevel enum value of an equivalent string.
@@ -14,4 +18,46 @@ export const getAlertLevel = (str: string): AlertLevel => {
   if (str.toLowerCase().includes('cancellation')) return AlertLevel.Cancellation;
 
   return AlertLevel.DO_NOT_USE;
+};
+
+/**
+ * `getEarthquakeLocDesc` parses a given `parameter_list` and returns a formatted
+ * string of the event's estimated magnitude and location.
+ * @example
+ * const parameterList = [
+      {
+        value: 'near the Tonga Islands',
+        valueName: 'EventLocationName',
+      },
+      {
+        value: '7.6',
+        valueName: 'EventPreliminaryMagnitude',
+      },
+      // ...
+    ];
+    getEarthquakeLocDesc(parameterList); // 'magnitude 7.6 earthquake near the Tonga Islands'
+ */
+export const getEarthquakeLocDesc = (
+  parameterList: CAP_1_2.Alert_info_list_info_parameter_list_parameter[]
+): string => {
+  if (!parameterList?.length) return '';
+
+  let eventLocation: string = '';
+  let eventPreliminaryMagnitude: string | number = '';
+
+  parameterList.forEach((param) => {
+    if (param.valueName === EVENT_LOC_NAME_VALUENAME) {
+      eventLocation = param.value;
+    }
+    if (param.valueName === EVENT_PRELIM_MAG_VALUENAME) {
+      eventPreliminaryMagnitude = param.value;
+    }
+  });
+
+  // if (!eventLocationNameParam || !eventPreliminaryMagnitudeParam) return '';
+
+  const magnitude = Number.parseFloat(`${eventPreliminaryMagnitude}`).toFixed(1);
+
+  if (!magnitude || !eventLocation) return '';
+  return `magnitude ${magnitude} earthquake ${eventLocation}`;
 };

--- a/functions/src/models/Alert/utils.ts
+++ b/functions/src/models/Alert/utils.ts
@@ -1,0 +1,17 @@
+import { AlertLevel } from './types';
+
+/**
+ * `getAlertLevel` returns the AlertLevel enum value of an equivalent string.
+ */
+export const getAlertLevel = (str: string): AlertLevel => {
+  if (!str?.toLowerCase()) return AlertLevel.DO_NOT_USE;
+
+  if (str.toLowerCase().includes('warning')) return AlertLevel.Warning;
+  if (str.toLowerCase().includes('advisory')) return AlertLevel.Advisory;
+  if (str.toLowerCase().includes('watch')) return AlertLevel.Watch;
+  if (str.toLowerCase().includes('information')) return AlertLevel.Information;
+  if (str.toLowerCase().includes('cancelation')) return AlertLevel.Cancellation;
+  if (str.toLowerCase().includes('cancellation')) return AlertLevel.Cancellation;
+
+  return AlertLevel.DO_NOT_USE;
+};

--- a/functions/src/models/Alert/utils.ts
+++ b/functions/src/models/Alert/utils.ts
@@ -54,8 +54,6 @@ export const getEarthquakeLocDesc = (
     }
   });
 
-  // if (!eventLocationNameParam || !eventPreliminaryMagnitudeParam) return '';
-
   const magnitude = Number.parseFloat(`${eventPreliminaryMagnitude}`).toFixed(1);
 
   if (!magnitude || !eventLocation) return '';

--- a/functions/src/models/index.ts
+++ b/functions/src/models/index.ts
@@ -3,7 +3,7 @@ import Event from './Event';
 import Participant from './Participant';
 import Phone from './Phone';
 import Geo from './Geo';
-export type { DBAlert } from './Alert';
+export type { DBAlert } from './Alert/types';
 export type { DBEvent } from './Event';
 export type { ParticipantArgs } from './Participant';
 export type { VerificationStatus } from './Phone';

--- a/functions/src/modules/SendAlert.ts
+++ b/functions/src/modules/SendAlert.ts
@@ -94,25 +94,17 @@ export default class SendAlert {
       }
     }
 
-    const handleError = (err: any) => {
-      const errMsg = new Error(`unable to send alert to participants: ${err?.message ?? err}`);
-      functions.logger.error('SendAlert.sendAlertToParticipants:error', { errorStack: errMsg.stack });
-      return Promise.reject(errMsg);
-    };
-
-    await Promise.allSettled(smsPromises.map(({ promise }) => promise))
-      .then((allSettledResult) => {
-        allSettledResult.forEach((result, index) => {
-          if (result.status === 'rejected') {
-            // Twilio promise already includes retrying
-            functions.logger.error(`SendAlert.sendAlertToParticipants:error: unable to deliver SMS: ${result.reason}`, {
-              phone: smsPromises[index].participant.phone?.number,
-              message: smsPromises[index].message,
-            });
-          }
-        });
-      })
-      .catch(handleError);
+    await Promise.allSettled(smsPromises.map(({ promise }) => promise)).then((allSettledResult) => {
+      allSettledResult.forEach((result, index) => {
+        if (result.status === 'rejected') {
+          // Twilio promise already includes retrying
+          functions.logger.error(`SendAlert.sendAlertToParticipants:error: unable to deliver SMS: ${result.reason}`, {
+            phone: smsPromises[index].participant.phone?.number,
+            message: smsPromises[index].message,
+          });
+        }
+      });
+    });
   };
 }
 

--- a/functions/src/test/SendAlert.test.ts
+++ b/functions/src/test/SendAlert.test.ts
@@ -176,7 +176,7 @@ describe('craftInfoSegmentMessage', () => {
         infoSegment,
         AlertLevel.Information,
         'magnitude 7.6 earthquake near the Tonga Islands'
-      ).includes('This message concerns an earthquake of magnitude 7.6 earthquake near the Tonga Islands')
+      ).includes('This message concerns an earthquake of magnitude 7.6 earthquake near the Tonga Islands.')
     ).toBe(true);
   });
 

--- a/functions/src/test/SendAlert.test.ts
+++ b/functions/src/test/SendAlert.test.ts
@@ -4,6 +4,7 @@ import Alert from '../models/Alert';
 import Participant from '../models/Participant';
 import Phone from '../models/Phone';
 import { readXML } from './test_utils';
+import { AlertLevel } from '../models/Alert/types';
 
 const mockParticipant = new Participant({
   id: 'active-and-verified',
@@ -139,38 +140,58 @@ describe('craftInfoSegmentMessage', () => {
     infoSegment = alert.toDB().info_list[0];
   });
 
-  it('returns an empty string if the language is not EN-US', async () => {
+  it('returns an empty string if the language is not EN-US', () => {
     infoSegment.language = 'es-mx';
     expect(craftInfoSegmentMessage(infoSegment)).toBe('');
   });
 
-  it('includes a headline if one exists', async () => {
+  it('includes a headline if one exists', () => {
     expect(craftInfoSegmentMessage(infoSegment).includes('This is a Tsunami Information Statement.')).toBe(true);
   });
 
-  it('includes a fallback headline if one does not exist', async () => {
+  it('includes a fallback headline if one does not exist', () => {
     infoSegment.headline = undefined;
     expect(craftInfoSegmentMessage(infoSegment).includes('A possible tsunami event has occurred.')).toBe(true);
   });
 
-  it('includes instructions if they exist', async () => {
+  it('includes instructions if they exist and the alertLevel is not Cancellation', () => {
     expect(
-      craftInfoSegmentMessage(infoSegment).includes('An earthquake has occurred; a tsunami is not expected.')
+      craftInfoSegmentMessage(infoSegment, AlertLevel.Information).includes(
+        'An earthquake has occurred; a tsunami is not expected.'
+      )
     ).toBe(true);
   });
 
-  it('removes redundant spaces within instructions', async () => {
+  it('includes the cancellation message if the alertLevel is Cancellation', () => {
+    expect(
+      craftInfoSegmentMessage(infoSegment, AlertLevel.Cancellation).includes(
+        'Tsunami cancellations indicate the end of the damaging tsunami threat.'
+      )
+    ).toBe(true);
+  });
+
+  it('includes the earthquake location description if it exists', () => {
+    expect(
+      craftInfoSegmentMessage(
+        infoSegment,
+        AlertLevel.Information,
+        'magnitude 7.6 earthquake near the Tonga Islands'
+      ).includes('This message concerns an earthquake of magnitude 7.6 earthquake near the Tonga Islands')
+    ).toBe(true);
+  });
+
+  it('removes redundant spaces within instructions', () => {
     expect(craftInfoSegmentMessage(infoSegment).includes('  ')).toBe(false);
   });
 
-  it('does not include instructions if none exists', async () => {
+  it('does not include instructions if none exists', () => {
     infoSegment.instruction = undefined;
     expect(
       craftInfoSegmentMessage(infoSegment).includes('An earthquake has occurred; a tsunami is not expected.')
     ).toBe(false);
   });
 
-  it('includes a link to the text bulletin if it exists', async () => {
+  it('includes a link to the text bulletin if it exists', () => {
     expect(
       craftInfoSegmentMessage(infoSegment).includes(
         'For more details, visit: http://ntwc.arh.noaa.gov/events/PAAQ/2022/06/04/rcz9ap/1/WEAK53/WEAK53.txt'
@@ -178,7 +199,7 @@ describe('craftInfoSegmentMessage', () => {
     ).toBe(true);
   });
 
-  it('does not include a link to the text bulletin if it does not exist', async () => {
+  it('does not include a link to the text bulletin if it does not exist', () => {
     infoSegment.web = undefined;
     expect(craftInfoSegmentMessage(infoSegment).includes('For more details')).toBe(false);
   });

--- a/functions/src/test/models/Alert.test.ts
+++ b/functions/src/test/models/Alert.test.ts
@@ -1,6 +1,6 @@
 import { CAP_1_2 } from 'cap-ts';
 import { Alert } from '../../models';
-import { AlertLevel } from '../../models/Alert';
+import { AlertLevel } from '../../models/Alert/types';
 import { readXML } from '../test_utils';
 
 const defaultCAPAlert = CAP_1_2.Alert.fromXML(readXML());

--- a/functions/src/test/models/Alert/Alert.test.ts
+++ b/functions/src/test/models/Alert/Alert.test.ts
@@ -1,7 +1,7 @@
 import { CAP_1_2 } from 'cap-ts';
-import { Alert } from '../../models';
-import { AlertLevel } from '../../models/Alert/types';
-import { readXML } from '../test_utils';
+import Alert from '../../../models/Alert';
+import { AlertLevel } from '../../../models/Alert/types';
+import { readXML } from '../../test_utils';
 
 const defaultCAPAlert = CAP_1_2.Alert.fromXML(readXML());
 

--- a/functions/src/test/models/Alert/utils.test.ts
+++ b/functions/src/test/models/Alert/utils.test.ts
@@ -1,0 +1,93 @@
+import { CAP_1_2 } from 'cap-ts';
+import { getAlertLevel, getEarthquakeLocDesc } from '../../../models/Alert/utils';
+import { AlertLevel } from '../../../models/Alert/types';
+
+describe('getAlertLevel', () => {
+  it('returns AlertLevel.DO_NOT_USE if the given string is empty/undefined', () => {
+    expect(getAlertLevel('')).toBe(AlertLevel.DO_NOT_USE);
+  });
+
+  it('returns AlertLevel.DO_NOT_USE if the given string is not matched', () => {
+    expect(getAlertLevel('blhadfsafjlkdsjf')).toBe(AlertLevel.DO_NOT_USE);
+  });
+
+  it('returns AlertLevel.Warning if the string contains "warning"', () => {
+    expect(getAlertLevel('Tsunami Warning')).toBe(AlertLevel.Warning);
+  });
+
+  it('returns AlertLevel.Advisory if the string contains "advisory"', () => {
+    expect(getAlertLevel('Tsunami Advisory')).toBe(AlertLevel.Advisory);
+  });
+
+  it('returns AlertLevel.Watch if the string contains "watch"', () => {
+    expect(getAlertLevel('Tsunami Watch')).toBe(AlertLevel.Watch);
+  });
+
+  it('returns AlertLevel.Information if the string contains "information"', () => {
+    expect(getAlertLevel('Tsunami Information')).toBe(AlertLevel.Information);
+  });
+
+  it('returns AlertLevel.Cancellation if the string contains "cancellation" (two els)', () => {
+    expect(getAlertLevel('Tsunami Cancellation')).toBe(AlertLevel.Cancellation);
+  });
+
+  it('returns AlertLevel.Cancellation if the string contains "cancelation" (one el)', () => {
+    expect(getAlertLevel('Tsunami Cancelation')).toBe(AlertLevel.Cancellation);
+  });
+});
+
+describe('getEarthquakeLocDesc', () => {
+  it('returns an empty string if no parameter list is empty', () => {
+    expect(getEarthquakeLocDesc([])).toBe('');
+  });
+
+  it('returns an empty string if no `EventLocationName` or `EventPreliminaryMagnitude` parameters are in the list', () => {
+    const parameterList = [
+      {
+        value: 'Ml',
+        valueName: 'EventPreliminaryMagnitudeType',
+      },
+    ];
+
+    expect(getEarthquakeLocDesc(parameterList)).toBe('');
+  });
+
+  it('returns a formatted string when both parameters are present', () => {
+    const parameterList = [
+      {
+        value: 'near the Tonga Islands',
+        valueName: 'EventLocationName',
+      },
+      {
+        value: '1',
+        valueName: 'EventPreliminaryMagnitude',
+      },
+      {
+        value: 'Ml',
+        valueName: 'EventPreliminaryMagnitudeType',
+      },
+    ];
+    expect(getEarthquakeLocDesc(parameterList)).toBe('magnitude 1.0 earthquake near the Tonga Islands');
+  });
+
+  it('handles numerical magnitude values', () => {
+    // Incongruent behavior seen when parsing XMLs
+    const parameterList = [
+      {
+        value: 'near the Tonga Islands',
+        valueName: 'EventLocationName',
+      },
+      {
+        value: 7.6,
+        valueName: 'EventPreliminaryMagnitude',
+      },
+      {
+        value: 'Ml',
+        valueName: 'EventPreliminaryMagnitudeType',
+      },
+    ];
+    expect(
+      getEarthquakeLocDesc(parameterList as unknown as CAP_1_2.Alert_info_list_info_parameter_list_parameter[])
+    ).toBe('magnitude 7.6 earthquake near the Tonga Islands');
+  });
+});


### PR DESCRIPTION
This PR adjusts `SendAlert` methods to add the event's earthquake description and to handle cancellation messages better. 

Previously, the SMS message for a non-cancellation message would appear thus:
```
Tsunami.events: This is a Tsunami Information Statement for Alaska, British Columbia, Washington, Oregon, and California.
There is no tsunami danger for the U.S. West Coast, British Columbia, or Alaska. Based on earthquake information and historic tsunami records, the earthquake is not expected to generate a tsunami. This will be the only U.S. National Tsunami Warning Center message for this event unless additional information becomes available. Refer to the internet site tsunami.gov for more information.
For more details, visit: http://ntwc.arh.noaa.gov/events/PAAQ/2022/09/19/rigy8l/1/WEAK53/WEAK53.txt
```

We add the earthquake description parsed from `info_list[0].parameter_list`:
```diff
 Tsunami.events: This is a Tsunami Information Statement for Alaska, British Columbia, Washington, Oregon, and California.
+This message concerns a magnitude 7.6 earthquake near the Tonga Islands.
 There is no tsunami danger for the U.S. West Coast, British Columbia, or Alaska. Based on earthquake information and historic tsunami records, the earthquake is not expected to generate a tsunami. This will be the only U.S. National Tsunami Warning Center message for this event unless additional information becomes available. Refer to the internet site tsunami.gov for more information.
 For more details, visit: http://ntwc.arh.noaa.gov/events/PAAQ/2022/09/19/rigy8l/1/WEAK53/WEAK53.txt
```

For cancellation messages (e.g. [PAAQ-13-r5qho6](https://tsunami.gov/events/PAAQ/2022/01/15/r5qho6/13/WEAK51/WEAK51.txt)), the message will now appear:
```diff
 Tsunami.events: The tsunami Advisory is canceled for the coastal areas of British Columbia from The Wash./BC Border  to North Vancouver Island, British Columbia.
+ This message concerns a magnitude 1.0 earthquake near the Tonga Islands.
+ Tsunami cancellations indicate the end of the damaging tsunami threat.  A cancellation is issued after an evaluation of sea level data confirms that a destructive tsunami will not impact the alerted region, or after tsunami levels have subsided to non-damaging levels.
- There is no tsunami danger for the U.S. West Coast, British Columbia, or Alaska. Based on earthquake information and historic tsunami records, the earthquake is not expected to generate a tsunami. This will be the only U.S. National Tsunami Warning Center message for this event unless additional information becomes available. Refer to the internet site tsunami.gov for more information.
 For more details, visit: https://tsunami.gov/events/PAAQ/2022/01/15/r5qho6/13/WEAK51/WEAK51.txt
```